### PR TITLE
Make bitmex::websocket::message public

### DIFF
--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -1,5 +1,5 @@
+pub mod message;
 mod command;
-mod message;
 mod topic;
 
 pub use self::command::Command;


### PR DESCRIPTION
So we could filter websocket messages easily.
```rust
    while let Some(msg) = client.next().await {
        match msg {
            Ok(msg) => match msg.clone() {
                BitMEXWsMessage::Table(mut t) => {
                    match t.table {
                        TradeBin1m => {
                            match t.action {
                                Action::Insert => {
                                    let trade_bin : TradeBin = serde_json::from_value(t.data[0].take()).unwrap();
                                    println!("{:?}", trade_bin);
                                }
                                _ => println!("TradeBin1m: not insert"),
                            }
                        },
                        _ => println!("Other table message."),
                    };
                },
                _ => println!("{:?}", msg)
            },
            Err(e) => panic!("{:?}", e)
        };
    }
```