### PR TITLE
re-exporting Value type

### DIFF
--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -2,6 +2,7 @@ mod command;
 mod message;
 mod topic;
 
+pub use serde_json::Value;
 pub use self::command::Command;
 pub use self::message::Message as BitMEXWsMessage;
 pub use self::message::{


### PR DESCRIPTION
Hello,

added one line to `websocket.rs` to re-export the serde json `Value` type; this is needed for proper manipulation with messages received from websockets.